### PR TITLE
Add GDR1777 RPG notebook link to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,7 @@ A curated list of tools related to notebooklm as well as examples of great podca
 - [Gipety hacker news casts](https://news.gipety.com/) - Podcasts of selected hacker news threads.
 - [Adding lipsync-ed talking heads to podcast audio](https://andresvarela.com/2024/09/how-i-used-notebooklm-for-an-elevator-pitch/) - Overview of the podcast technology with free/freemium tools to go further and generate avatars.
 - [HCI Deep Dives](https://www.deep-hci.org/) - Podcasts of selected Human Computer Interaction Papers using NotebookML and podcastfy.
+- [GDR1777 RPG notebook](https://notebooklm.google.com/notebook/46610caf-126a-42da-989b-981b1866bd1d) - A command-driven role-playing game inside a public notebook: type #GDR and the sources become the game world, with an action budget, cited facts and in-game Studio artifacts.
 
 ## Community
 


### PR DESCRIPTION
Adding an example of a different kind: not a podcast but an interactive notebook — a command-driven RPG built entirely with custom chat instructions on a public notebook. The sources are the game world (Sherlock Holmes, the Oscar Wilde trial, Grimm tales, the Bitcoin and Lightning Network books, the Wright brothers' first flight, Gagarin, the Transformer paper); the game master tracks an action budget, cites facts from the sources, and triggers Studio artifacts diegetically — quizzes as in-game trials, debate Audio Overviews as discordant witnesses. Italian-first, plays in English on request.